### PR TITLE
Added missing methods and replaced { literals } with #(literals)

### DIFF
--- a/book/02-Perceptron/02-chapter2.markdown
+++ b/book/02-Perceptron/02-chapter2.markdown
@@ -411,20 +411,20 @@ We can now train a perceptron to actually learn how to express the logical gates
 PerceptronTest>>testTrainingOR
 	| p |
 	p := Neuron new.
-	p weights: { -1 . -1 }.
+	p weights: #(-1 -1).
 	p bias: 2.
 	
 	40 timesRepeat: [ 
-		p train: { 0 . 0 } desiredOutput: 0.
-		p train: { 0 . 1 } desiredOutput: 1.
-		p train: { 1 . 0 } desiredOutput: 1.
-		p train: { 1 . 1 } desiredOutput: 1.
+		p train: #(0 0) desiredOutput: 0.
+		p train: #(0 1) desiredOutput: 1.
+		p train: #(1 0) desiredOutput: 1.
+		p train: #(1 1) desiredOutput: 1.
 	].
 	
-	self assert: (p feed: { 0 . 0 }) equals: 0.
-	self assert: (p feed: { 0 . 1 }) equals: 1.
-	self assert: (p feed: { 1 . 0 }) equals: 1.
-	self assert: (p feed: { 1 . 1 }) equals: 1.
+	self assert: (p feed: #(0 0)) equals: 0.
+	self assert: (p feed: #(0 1)) equals: 1.
+	self assert: (p feed: #(1 0)) equals: 1.
+	self assert: (p feed: #(1 1)) equals: 1.
 ~~~~~~~
 
 The method `testTrainingOR` first creates a perceptron with some arbitrary weights and bias. We successfully train it with the four possible combinations of the OR logical gate. After the training, we test the perceptron to see if it has properly learned.
@@ -621,7 +621,7 @@ f := [ :x | (-2 * x) - 3 ].
 0 to: 2000 by: 10 do: [ :nbOfTrained |
 	r := Random new seed: 42.
 	p := Neuron new.
-	p weights: { 1 . 2 }.
+	p weights: #(1 2).
 	p bias: -1.
 
 	nbOfTrained timesRepeat: [ 

--- a/book/03-Neuron/03-chapter3.markdown
+++ b/book/03-Neuron/03-chapter3.markdown
@@ -189,13 +189,13 @@ PerceptronTest>>testAND
     | p |
 	p := Neuron new.
 	p step. "<= new line"
-    p weights: { 1 . 1 }.
+    p weights: #(1 1).
     p bias: -1.5.
     
-    self assert: (p feed: { 0 . 0 }) equals: 0.
-    self assert: (p feed: { 0 . 1 }) equals: 0.
-    self assert: (p feed: { 1 . 0 }) equals: 0.
-    self assert: (p feed: { 1 . 1 }) equals: 1.
+    self assert: (p feed: #(0 0)) equals: 0.
+    self assert: (p feed: #(0 1)) equals: 0.
+    self assert: (p feed: #(1 0)) equals: 0.
+    self assert: (p feed: #(1 1)) equals: 1.
 ```
 
 Adding the call to `step` make the neuron behaves as a perceptron. Omitting this line would instead use a sigmoid neuron, and the tests would fail since the output would not exactly be `0` or `1`.
@@ -219,20 +219,20 @@ We can then train a neuron to learn some logical gates. The following method is 
 NeuronTest>>testTrainingAND
 	| p |
 	p := Neuron new.
-	p weights: {-1 . -1}.
+	p weights: #(-1 -1).
 	p bias: 2.
 	
 	5000
 		timesRepeat: [ 
-			p train: {0 . 0} desiredOutput: 0.
-			p train: {0 . 1} desiredOutput: 0.
-			p train: {1 . 0} desiredOutput: 0.
-			p train: {1 . 1} desiredOutput: 1 ].
+			p train: #(0 0) desiredOutput: 0.
+			p train: #(0 1) desiredOutput: 0.
+			p train: #(1 0) desiredOutput: 0.
+			p train: #(1 1) desiredOutput: 1 ].
 		
-	self assert: ((p feed: {0 . 0}) closeTo: 0 precision: 0.1).
-	self assert: ((p feed: {0 . 1}) closeTo: 0 precision: 0.1).
-	self assert: ((p feed: {1 . 0}) closeTo: 0 precision: 0.1).
-	self assert: ((p feed: {1 . 1}) closeTo: 1 precision: 0.1).
+	self assert: ((p feed: #(0 0)) closeTo: 0 precision: 0.1).
+	self assert: ((p feed: #(0 1)) closeTo: 0 precision: 0.1).
+	self assert: ((p feed: #(1 0)) closeTo: 0 precision: 0.1).
+	self assert: ((p feed: #(1 1)) closeTo: 1 precision: 0.1).
 ```
 
 There are two differences:
@@ -245,20 +245,20 @@ Similarly we can train a sigmoid neuron to learn the OR behavior:
 NeuronTest>>testTrainingOR
 	| p |
 	p := Neuron new.
-	p weights: {-1 . -1}.
+	p weights: #(-1 -1).
 	p bias: 2.
 	
 	5000
 		timesRepeat: [ 
-			p train: {0 . 0} desiredOutput: 0.
-			p train: {0 . 1} desiredOutput: 1.
-			p train: {1 . 0} desiredOutput: 1.
-			p train: {1 . 1} desiredOutput: 1 ].
+			p train: #(0 0) desiredOutput: 0.
+			p train: #(0 1) desiredOutput: 1.
+			p train: #(1 0) desiredOutput: 1.
+			p train: #(1 1) desiredOutput: 1 ].
 		
-	self assert: ((p feed: {0 . 0}) closeTo: 0 precision: 0.1).
-	self assert: ((p feed: {0 . 1}) closeTo: 1 precision: 0.1).
-	self assert: ((p feed: {1 . 0}) closeTo: 1 precision: 0.1).
-	self assert: ((p feed: {1 . 1}) closeTo: 1 precision: 0.1).
+	self assert: ((p feed: #(0 0)) closeTo: 0 precision: 0.1).
+	self assert: ((p feed: #(0 1)) closeTo: 1 precision: 0.1).
+	self assert: ((p feed: #(1 0)) closeTo: 1 precision: 0.1).
+	self assert: ((p feed: #(1 1)) closeTo: 1 precision: 0.1).
 ```
 
 As you can see, using a sigmoid neuron does not mess up our tests. We simply need (i) to increase the number of epochs to which we train the neuron, and we need (ii) to be more careful when comparing floating values.
@@ -276,19 +276,19 @@ learningCurveNeuron := OrderedCollection new.
 0 to: 1000 do: [ :nbOfTrained |
     r := Random new seed: 42.
     p := Neuron new.
-    p weights: {-1 . -1}.
+    p weights: #(-1 -1).
     p bias: 2.
 
     nbOfTrained timesRepeat: [ 
-        p train: {0 . 0} desiredOutput: 0.
-        p train: {0 . 1} desiredOutput: 0.
-        p train: {1 . 0} desiredOutput: 0.
-        p train: {1 . 1} desiredOutput: 1 ].
+        p train: #(0 0) desiredOutput: 0.
+        p train: #(0 1) desiredOutput: 0.
+        p train: #(1 0) desiredOutput: 0.
+        p train: #(1 1) desiredOutput: 1 ].
    
-    res :=  ((p feed: {0 . 0}) - 0) abs + 
-            ((p feed: {0 . 1}) - 0) abs +
-            ((p feed: {1 . 0}) - 0) abs +
-            ((p feed: {1 . 1}) - 1) abs.
+    res :=  ((p feed: #(0 0)) - 0) abs + 
+            ((p feed: #(0 1)) - 0) abs +
+            ((p feed: #(1 0)) - 0) abs +
+            ((p feed: #(1 1)) - 1) abs.
      learningCurveNeuron add: res / 4.
     
 ].
@@ -298,19 +298,19 @@ learningCurvePerceptron := OrderedCollection new.
     r := Random new seed: 42.
     p := Neuron new.
 	 p step.
-    p weights: {-1 . -1}.
+    p weights: #(-1 -1).
     p bias: 2.
 
     nbOfTrained timesRepeat: [ 
-        p train: {0 . 0} desiredOutput: 0.
-        p train: {0 . 1} desiredOutput: 0.
-        p train: {1 . 0} desiredOutput: 0.
-        p train: {1 . 1} desiredOutput: 1 ].
+        p train: #(0 0) desiredOutput: 0.
+        p train: #(0 1) desiredOutput: 0.
+        p train: #(1 0) desiredOutput: 0.
+        p train: #(1 1) desiredOutput: 1 ].
    
-    res :=  ((p feed: {0 . 0}) - 0) abs + 
-            ((p feed: {0 . 1}) - 0) abs +
-            ((p feed: {1 . 0}) - 0) abs +
-            ((p feed: {1 . 1}) - 1) abs.
+    res :=  ((p feed: #(0 0)) - 0) abs + 
+            ((p feed: #(0 1)) - 0) abs +
+            ((p feed: #(1 0)) - 0) abs +
+            ((p feed: #(1 1)) - 1) abs.
      learningCurvePerceptron add: res / 4.
     
 ].

--- a/book/04-NeuralNetwork/04-chapter1.markdown
+++ b/book/04-NeuralNetwork/04-chapter1.markdown
@@ -128,9 +128,11 @@ NeuronLayerTest>>testBasic
 
 	self assert: nl isOutputLayer.
 
-	result := nl feed: { 1 . 2 . 3 . 4 }.
+	result := nl feed: $(1 2 3 4).
 	self assert: result size equals: 3.
- 	self assert: result closeTo: #(0.037000501309787576 0.9051275824569505 0.9815269659126287)
+	result
+		with: #(0.03700050130978758 0.9051275824569505 0.9815269659126287)
+		do: [ :res :test | self assert: (res closeTo: test precision: 0.0000000001) ]
 ```
 
 The method `testBasic` create a new neuron layer, composed of 3 neurons, each having 4 weights and 1 bias. The weights and biases are initialized using the random number generator `r`.
@@ -142,18 +144,17 @@ NeuronLayerTest>>testOutputLayer
 	random := Random seed: 42.
 	nl1 := NeuronLayer new.
 	nl1 initializeNbOfNeurons: 3 nbOfWeights: 4 using: random.
-
 	nl2 := NeuronLayer new.
 	nl2 initializeNbOfNeurons: 4 nbOfWeights: 3 using: random.
 	nl1 nextLayer: nl2.
-
 	self deny: nl1 isOutputLayer.
 	self assert: nl2 isOutputLayer.
-
-	result := nl1 feed: { 1 . 2 . 3 . 4 }.
+	result := nl1 feed: #(1 2 3 4).
 	"Since nl2 has 4 neurons, we will obtain 4 outputs"
 	self assert: result size equals: 4.
- 	self assert: result closeTo: #(0.030894022895187584 0.9220488835263312 0.5200462953493653 0.20276557516858304)
+	result
+		with: #(0.03089402289518759 0.9220488835263312 0.5200462953493654 0.20276557516858304)
+		do: [ :r :test | self assert: (r closeTo: test precision: 0.0000000001) ]
 ```
 
 We can now wrap a chain of layers into a neural network.
@@ -247,7 +248,7 @@ NNetworkTest>>testBasic
     | n |
     n := NNetwork new.
     n configure: 2 hidden: 2 nbOfOutputs: 1.
-    self assert: (n feed: { 1 . 3 }) closeTo: #(0.6745388083637035).
+    self assert: ((n feed: #(1 3)) anyOne closeTo: 0.6745388083637036 precision: 0.0000000001)
     self assert: n numberOfOutputs equals: 1
 ```
 
@@ -441,16 +442,16 @@ NNetworkTest>>testXOR
 	n configure: 2 hidden: 3 nbOfOutputs: 1.
 
 	10000 timesRepeat: [ 
-		n train: { 0 . 0 } desiredOutputs: { 0 }.	
-		n train: { 0 . 1 } desiredOutputs: { 1 }.
-		n train: { 1 . 0 } desiredOutputs: { 1 }.
-		n train: { 1 . 1 } desiredOutputs: { 0 }.
+		n train: #(0 0) desiredOutputs: #(0).	
+		n train: #(0 1) desiredOutputs: #(1).
+		n train: #(1 0) desiredOutputs: #(1).
+		n train: #(1 1) desiredOutputs: #(0).
 	].
 
-	self assert: (n feed: { 0 . 0 }) first < 0.1.
-	self assert: (n feed: { 0 . 1 }) first > 0.9.
-	self assert: (n feed: { 1 . 0 }) first > 0.9.
-	self assert: (n feed: { 1 . 1 }) first < 0.1.
+	self assert: (n feed: #(0 0)) first < 0.1.
+	self assert: (n feed: #(0 1)) first > 0.9.
+	self assert: (n feed: #(1 0)) first > 0.9.
+	self assert: (n feed: #(1 1)) first < 0.1.
 ```
 
 If you try to decrease the `10000` to a low value, `10` for example, the network does not receive enough training and the test ultimately fails.


### PR DESCRIPTION
First of all, thank you for creating the Agile machine learning page!

A few changes I'd recommend are:
- Several methods are missing from NNetwork, this may be considered an exercise for the reader
- Several tests like NeuronLayerTest>>testOutputLayer depend on floating point percision testing, which failed between different version of Pharo, I found using #closeTo:precision: is helpful
- One of NormalizationTest methods could use a more descriptive name
- Preference for #() instead of {} (where literals are used).
