### PR TITLE
Fixing small mistakes in some chapters

### DIFF
--- a/book/02-Perceptron/02-chapter2.markdown
+++ b/book/02-Perceptron/02-chapter2.markdown
@@ -554,7 +554,7 @@ We will now see a new application of the perceptron. A perceptron can be used to
 - A space composed of red and blue points
 - A straight line divides the red points from the blue points
 
-Consider the following interaction between two (real) people, a teacher and a student. The goal of the teacher is to let the student infer where is the straight separation line between the blue and the red points. First, the teacher can gives an arbitrary number of examples. Each example is given to the student as a location and a color. After a few examples, the students is able to guess the color of a random location. Intuitively, more examples the teacher will give to the student, more the student will be likely to correctly predict the color of a location.
+Consider the following interaction between two (real) people, a teacher and a student. The goal of the teacher is to let the student infer where is the straight separation line between the blue and the red points. First, the teacher can give an arbitrary number of examples. Each example is given to the student as a location and a color. After a few examples, the students is able to guess the color of a random location. Intuitively, more examples the teacher will give to the student, more the student will be likely to correctly predict the color of a location.
 
 Some questions arise:
 
@@ -593,7 +593,7 @@ The script begins by defining a set of 500 points, ranging within a squared area
 
 We assign to the variable `f` a block representing our function $f(x)$, written in the Pharo syntax. A block may be evaluated with the message `value:`. For example, we have `f value: 3` that returns `-9` and `f value: -2` that returns `1`.
 
-The remainder of the script uses Grapher to plot the points. A point `p` is red if `p y` is greater than `f value: p x`, else it is blue. The expression `Color red trans` evaluates to a transparent red color. 
+The remainder of the script uses Grapher to plot the points. A point `p` is red if `p second` is greater than `f value: p first`, else it is blue. The expression `Color red trans` evaluates to a transparent red color. 
 
 We can add the actual line defined by `f` to our graph. Consider the small revision (Figure @fig:simpleLine2):
 

--- a/book/03-Neuron/03-chapter3.markdown
+++ b/book/03-Neuron/03-chapter3.markdown
@@ -3,7 +3,7 @@
 
 In the previous chapter we have seen how a perceptron operates and how a simple learning algorithm can be implemented. However, the perceptron has some serious limitations, which will motivate us to formulate a more robust artificial neuron, called the sigmoid neuron.
 
-This chapters uses Roassal to plot values. As seen in the previous chapter, Roassal may be loaded in Pharo by executing the following script in a playground:
+This chapter uses Roassal to plot values. As seen in the previous chapter, Roassal may be loaded in Pharo by executing the following script in a playground:
 
 ```Smalltalk
 Metacello new

--- a/book/04-NeuralNetwork/04-chapter.markdown
+++ b/book/04-NeuralNetwork/04-chapter.markdown
@@ -75,13 +75,13 @@ NeuronLayer>>feed: someInputValues
 		ifFalse: [ nextLayer feed: someOutputs ]
 ```
 
-The method invokes `feed:` on each of its neurons (the method `Neuron>>feed:` is detailed in the previous chapter). The results is then kept as an array. The method then checks if the layer is an output layer. If this is the case, the result of the method is simply the results of each neurons. If the layer is not an output (_i.e.,_ it is  an hidden layer), we feed-forward the computed values to the next layer.
+The method invokes `feed:` on each of its neurons (the method `Neuron>>feed:` is detailed in the previous chapter). The results are then kept as an array. The method then checks if the layer is an output layer. If this is the case, the result of the method is simply the results of each neurons. If the layer is not an output (_i.e.,_ it is a hidden layer), we feed-forward the computed values to the next layer.
 
 
 We need to determine if a neuron layer is the output layer or not. We can easily achieve this using the predicate `isOutputLayer`:
 ```Smalltalk
 NeuronLayer>>isOutputLayer
-	"Return true of the layer is the output layer (i.e., the last layer, right-most, in the network)"
+	"Return true if the layer is the output layer (i.e., the last layer, right-most, in the network)"
 	^ self nextLayer isNil
 ```
 
@@ -383,7 +383,7 @@ Once the neuron in the output layer have their delta value adjusted, previous la
 NeuronLayer>>backwardPropagateError
 	"This is a recursive method. The back propagation begins with the output layer (i.e., the last layer)"
 
-	"We are in an hidden layer"
+	"We are in a hidden layer"
 	neurons doWithIndex: [ :neuron :j |
 		| theError |
 		theError := 0.0.


### PR DESCRIPTION
Hello,
I found a little grammatical error in this chapter: "the teacher can gives" -> "the teacher can give"
Also the code of the Figures 11, 12 of the section 1.9 does not match with the code examples, the text (that I changed) and Figure 13, although they do the same. I changed the text under the Figure 11 to patch those differences (matching the text with the code examples, and Fig 13), but I would suggest a change for Figures 11 and 12, or a change for all code examples and even Figure 13.